### PR TITLE
Pixel fallback when using rem in relative-size

### DIFF
--- a/stylesheets/stitch/patterns/text/_rem.scss
+++ b/stylesheets/stitch/patterns/text/_rem.scss
@@ -1,3 +1,6 @@
 @function relative-size($size,$context,$unit:em) {
-	@return #{$size/$context}$unit;
+  @if $unit == rem {
+    @return #{$size}px;
+  }
+  @return #{$size/$context}$unit;
 }


### PR DESCRIPTION
<del>It might be an idea to provide a pixel fallback when using `rem` in `relative-size`.</del>


<del>See http://blog.typekit.com/2011/11/09/type-study-sizing-the-legible-letter/</del>


<del>Thanks,<del>

<del>David</del>


Just spotted a stupid error. This is a function, not a mixin, so it will only return the pixel value when using rem.
