### PR TITLE
Removed text-align property from inline-icon mixin

### DIFF
--- a/stylesheets/stitch/patterns/images/_inline-icon.scss
+++ b/stylesheets/stitch/patterns/images/_inline-icon.scss
@@ -3,16 +3,22 @@
 	Pass through an asset, and optionally a padding value, x-position and y-position.
 	
 	.icon {
-		@include inline-icon('icons/gowalla_16.png', 30px);
+		@include inline-icon('icons/gowalla_16.png', 30px, right);
 	}
 	
 	<a href="#" class="icon">Sweet icon</a>
 */
 
-@mixin inline-icon($img, $spacing:5px, $x-pos: left, $y-pos: top) {
-   background-image:image-url($img);
-   background-position: $x-pos $y-pos;
-   background-repeat: no-repeat; 
-   line-height:image-height($img);
-   padding-#{$x-pos}:image-width($img) + $spacing;
+@mixin inline-icon($img, $spacing:5px, $pos: left) {
+	background-image:image-url($img);
+	background-repeat: no-repeat; 
+	@if $pos == right {
+		background-position: right top;
+		text-align: right;
+	} @else {
+		background-position: left top;
+		text-align: left;
+	}
+	line-height:image-height($img);
+	padding-#{$pos}:image-width($img) + $spacing;
 }

--- a/stylesheets/stitch/patterns/images/_inline-icon.scss
+++ b/stylesheets/stitch/patterns/images/_inline-icon.scss
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 /* 
 	Add an icon to an inline element. E.g anchor or span
 	Pass through an asset, and optionally a padding value, x-position and y-position.
@@ -16,5 +15,4 @@
    background-repeat: no-repeat; 
    line-height:image-height($img);
    padding-#{$x-pos}:image-width($img) + $spacing;
-   text-align: $x-pos; 
 }


### PR DESCRIPTION
I removed this so people could just control this themselves.
What if someone added 358px, how would you align the text then?
It was a case of trying to be too smart
