### PR TITLE
Fixes for Opera.

### DIFF
--- a/stylesheets/stitch/patterns/_css3.scss
+++ b/stylesheets/stitch/patterns/_css3.scss
@@ -191,7 +191,7 @@ $default-prefixes-columns: -webkit, -moz;
 // Transforms
 // ----------------------------------------
 
-$default-prefixes-transform: -webkit, -moz;
+$default-prefixes-transform: -webkit, -moz, -o;
 
 // @see http://www.w3.org/TR/css3-2d-transforms/#transform-property
 @mixin transform($v, $prefixes:$default-prefixes-transform) {
@@ -227,7 +227,7 @@ $default-prefixes-transform: -webkit, -moz;
 // ----------------------------------------
 // @see http://www.w3.org/TR/css3-transitions/
 
-$default-prefixes-transition: -webkit, -moz;
+$default-prefixes-transition: -webkit, -moz, -o;
 
 @mixin transition-property($v, $prefixes:$default-prefixes-transform) {
 	@include prefix(transition-property,$v,$prefixes);
@@ -257,7 +257,7 @@ $default-prefixes-transition: -webkit, -moz;
 // Animation
 // ----------------------------------------
 
-$default-prefixes-animation: -webkit, -moz;
+$default-prefixes-animation: -webkit, -moz, -o;
 
 @mixin animation($v, $prefixes:$default-prefixes-animation) {
 	@include prefix(animation,$v,$prefixes);

--- a/stylesheets/stitch/patterns/animation/_keyframes.scss
+++ b/stylesheets/stitch/patterns/animation/_keyframes.scss
@@ -1,5 +1,6 @@
 @mixin keyframes {
   @-webkit-keyframes { @content; }
   @-moz-keyframes { @content; }
+	@-o-keyframes { @content; }
   @keyframes { @content; }
 }


### PR DESCRIPTION
Opera Next just landed support for CSS Animations (http://my.opera.com/desktopteam/blog/2012/03/26/html5-css-64bit).

Added -o- for animations (will appear in Opera 12).
Added default prefix to transitions, transforms, and animations.
